### PR TITLE
Code improvements & modernisation

### DIFF
--- a/Windows Build Identifier/VHDInstallProviderInterface.cs
+++ b/Windows Build Identifier/VHDInstallProviderInterface.cs
@@ -8,20 +8,22 @@ namespace WindowsBuildIdentifier
 {
     public class VHDInstallProviderInterface : WindowsInstallProviderInterface
     {
-        private Stream _vhdstream;
-        private Disk vhd;
-        private NtfsFileSystem _ntfs;
+        private readonly Stream _vhdstream;
+        private readonly Disk _vhd;
+        private readonly NtfsFileSystem _ntfs;
 
         public VHDInstallProviderInterface(Stream vhdstream)
         {
             _vhdstream = vhdstream;
-            vhd = new Disk(_vhdstream, DiscUtils.Streams.Ownership.Dispose);
-            
+            _vhd = new Disk(_vhdstream, DiscUtils.Streams.Ownership.Dispose);
+
             PartitionInfo part = null;
-            foreach (var partition in vhd.Partitions.Partitions)
+            foreach (var partition in _vhd.Partitions.Partitions)
             {
                 if (part == null)
+                {
                     part = partition;
+                }
                 else
                 {
                     if (partition.SectorCount > part.SectorCount)
@@ -36,7 +38,7 @@ namespace WindowsBuildIdentifier
 
         public void Close()
         {
-            vhd.Dispose();
+            _vhd.Dispose();
         }
 
         public string ExpandFile(string Entry)
@@ -44,10 +46,8 @@ namespace WindowsBuildIdentifier
             var tmp = Path.GetTempFileName();
             using (var srcstrm = _ntfs.OpenFile(Entry, FileMode.Open))
             {
-                using (var dststrm = new FileStream(tmp, FileMode.Append))
-                {
-                    srcstrm.CopyTo(dststrm);
-                }
+                using var dststrm = new FileStream(tmp, FileMode.Append);
+                srcstrm.CopyTo(dststrm);
             }
 
             return tmp;

--- a/Windows Build Identifier/WIMInstallProviderInterface.cs
+++ b/Windows Build Identifier/WIMInstallProviderInterface.cs
@@ -1,16 +1,16 @@
 ﻿/*
  * Copyright (c) 2020, Gustave Monce - gus33000.me - @gus33000
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense,
  * and/or sell copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21,6 +21,7 @@
  */
 
 using SevenZipExtractor;
+using System;
 using System.IO;
 using System.Linq;
 
@@ -28,9 +29,9 @@ namespace WindowsBuildIdentifier
 {
     public class WIMInstallProviderInterface : WindowsInstallProviderInterface
     {
-        private Stream _wimstream;
-        private string _index;
-        private ArchiveFile archiveFile;
+        private readonly Stream _wimstream;
+        private readonly string _index;
+        private readonly ArchiveFile archiveFile;
 
         public WIMInstallProviderInterface(Stream wimstream, string index)
         {
@@ -43,10 +44,12 @@ namespace WindowsBuildIdentifier
         {
             string pathprefix = string.IsNullOrEmpty(_index) ? "" : _index + @"\";
 
-            if (!archiveFile.Entries.Any(x => x.FileName.ToLower() == (pathprefix + Entry).ToLower()))
+            if (!archiveFile.Entries.Any(x => x.FileName.Equals(pathprefix + Entry, StringComparison.InvariantCultureIgnoreCase)))
+            {
                 return null;
+            }
 
-            Entry wimEntry = archiveFile.Entries.First(x => x.FileName.ToLower() == (pathprefix + Entry).ToLower());
+            Entry wimEntry = archiveFile.Entries.First(x => x.FileName.Equals(pathprefix + Entry, StringComparison.InvariantCultureIgnoreCase));
 
             string tmp = Path.GetTempFileName();
             wimEntry.Extract(tmp);
@@ -61,7 +64,9 @@ namespace WindowsBuildIdentifier
             string[] entries = archiveFile.Entries.Where(x => x.FileName.StartsWith(pathprefix)).Select(x =>
             {
                 if (!string.IsNullOrEmpty(pathprefix))
-                    return x.FileName.Replace(pathprefix, "");
+                {
+                    return x.FileName.Substring(2);
+                }
 
                 return x.FileName;
             }).ToArray();

--- a/Windows Build Identifier/WindowsInstallProviderInterface.cs
+++ b/Windows Build Identifier/WindowsInstallProviderInterface.cs
@@ -1,16 +1,16 @@
 ﻿/*
  * Copyright (c) 2020, Gustave Monce - gus33000.me - @gus33000
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense,
  * and/or sell copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Windows Build Identifier/XmlFormats/WIM.cs
+++ b/Windows Build Identifier/XmlFormats/WIM.cs
@@ -1,16 +1,16 @@
 ﻿/*
  * Copyright (c) 2020, Gustave Monce - gus33000.me - @gus33000
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense,
  * and/or sell copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,109 +24,109 @@ using System.Xml.Serialization;
 
 namespace WindowsBuildIdentifier.XmlFormats
 {
-	public class WIMXml
+    public class WIMXml
     {
-		[XmlRoot(ElementName = "CREATIONTIME")]
-		public class CREATIONTIME
-		{
-			[XmlElement(ElementName = "HIGHPART")]
-			public string HIGHPART { get; set; }
-			[XmlElement(ElementName = "LOWPART")]
-			public string LOWPART { get; set; }
-		}
+        [XmlRoot(ElementName = "CREATIONTIME")]
+        public class CREATIONTIME
+        {
+            [XmlElement(ElementName = "HIGHPART")]
+            public string HIGHPART { get; set; }
+            [XmlElement(ElementName = "LOWPART")]
+            public string LOWPART { get; set; }
+        }
 
-		[XmlRoot(ElementName = "LASTMODIFICATIONTIME")]
-		public class LASTMODIFICATIONTIME
-		{
-			[XmlElement(ElementName = "HIGHPART")]
-			public string HIGHPART { get; set; }
-			[XmlElement(ElementName = "LOWPART")]
-			public string LOWPART { get; set; }
-		}
+        [XmlRoot(ElementName = "LASTMODIFICATIONTIME")]
+        public class LASTMODIFICATIONTIME
+        {
+            [XmlElement(ElementName = "HIGHPART")]
+            public string HIGHPART { get; set; }
+            [XmlElement(ElementName = "LOWPART")]
+            public string LOWPART { get; set; }
+        }
 
-		[XmlRoot(ElementName = "LANGUAGES")]
-		public class LANGUAGES
-		{
-			[XmlElement(ElementName = "LANGUAGE")]
-			public string LANGUAGE { get; set; }
-			[XmlElement(ElementName = "DEFAULT")]
-			public string DEFAULT { get; set; }
-		}
+        [XmlRoot(ElementName = "LANGUAGES")]
+        public class LANGUAGES
+        {
+            [XmlElement(ElementName = "LANGUAGE")]
+            public string LANGUAGE { get; set; }
+            [XmlElement(ElementName = "DEFAULT")]
+            public string DEFAULT { get; set; }
+        }
 
-		[XmlRoot(ElementName = "VERSION")]
-		public class VERSION
-		{
-			[XmlElement(ElementName = "MAJOR")]
-			public string MAJOR { get; set; }
-			[XmlElement(ElementName = "MINOR")]
-			public string MINOR { get; set; }
-			[XmlElement(ElementName = "BUILD")]
-			public string BUILD { get; set; }
-			[XmlElement(ElementName = "SPBUILD")]
-			public string SPBUILD { get; set; }
-			[XmlElement(ElementName = "SPLEVEL")]
-			public string SPLEVEL { get; set; }
-		}
+        [XmlRoot(ElementName = "VERSION")]
+        public class VERSION
+        {
+            [XmlElement(ElementName = "MAJOR")]
+            public string MAJOR { get; set; }
+            [XmlElement(ElementName = "MINOR")]
+            public string MINOR { get; set; }
+            [XmlElement(ElementName = "BUILD")]
+            public string BUILD { get; set; }
+            [XmlElement(ElementName = "SPBUILD")]
+            public string SPBUILD { get; set; }
+            [XmlElement(ElementName = "SPLEVEL")]
+            public string SPLEVEL { get; set; }
+        }
 
-		[XmlRoot(ElementName = "WINDOWS")]
-		public class WINDOWS
-		{
-			[XmlElement(ElementName = "ARCH")]
-			public string ARCH { get; set; }
-			[XmlElement(ElementName = "PRODUCTNAME")]
-			public string PRODUCTNAME { get; set; }
-			[XmlElement(ElementName = "EDITIONID")]
-			public string EDITIONID { get; set; }
-			[XmlElement(ElementName = "INSTALLATIONTYPE")]
-			public string INSTALLATIONTYPE { get; set; }
-			[XmlElement(ElementName = "HAL")]
-			public string HAL { get; set; }
-			[XmlElement(ElementName = "PRODUCTTYPE")]
-			public string PRODUCTTYPE { get; set; }
-			[XmlElement(ElementName = "PRODUCTSUITE")]
-			public string PRODUCTSUITE { get; set; }
-			[XmlElement(ElementName = "LANGUAGES")]
-			public LANGUAGES LANGUAGES { get; set; }
-			[XmlElement(ElementName = "VERSION")]
-			public VERSION VERSION { get; set; }
-			[XmlElement(ElementName = "SYSTEMROOT")]
-			public string SYSTEMROOT { get; set; }
-		}
+        [XmlRoot(ElementName = "WINDOWS")]
+        public class WINDOWS
+        {
+            [XmlElement(ElementName = "ARCH")]
+            public string ARCH { get; set; }
+            [XmlElement(ElementName = "PRODUCTNAME")]
+            public string PRODUCTNAME { get; set; }
+            [XmlElement(ElementName = "EDITIONID")]
+            public string EDITIONID { get; set; }
+            [XmlElement(ElementName = "INSTALLATIONTYPE")]
+            public string INSTALLATIONTYPE { get; set; }
+            [XmlElement(ElementName = "HAL")]
+            public string HAL { get; set; }
+            [XmlElement(ElementName = "PRODUCTTYPE")]
+            public string PRODUCTTYPE { get; set; }
+            [XmlElement(ElementName = "PRODUCTSUITE")]
+            public string PRODUCTSUITE { get; set; }
+            [XmlElement(ElementName = "LANGUAGES")]
+            public LANGUAGES LANGUAGES { get; set; }
+            [XmlElement(ElementName = "VERSION")]
+            public VERSION VERSION { get; set; }
+            [XmlElement(ElementName = "SYSTEMROOT")]
+            public string SYSTEMROOT { get; set; }
+        }
 
-		[XmlRoot(ElementName = "IMAGE")]
-		public class IMAGE
-		{
-			[XmlElement(ElementName = "DIRCOUNT")]
-			public string DIRCOUNT { get; set; }
-			[XmlElement(ElementName = "FILECOUNT")]
-			public string FILECOUNT { get; set; }
-			[XmlElement(ElementName = "TOTALBYTES")]
-			public string TOTALBYTES { get; set; }
-			[XmlElement(ElementName = "HARDLINKBYTES")]
-			public string HARDLINKBYTES { get; set; }
-			[XmlElement(ElementName = "CREATIONTIME")]
-			public CREATIONTIME CREATIONTIME { get; set; }
-			[XmlElement(ElementName = "LASTMODIFICATIONTIME")]
-			public LASTMODIFICATIONTIME LASTMODIFICATIONTIME { get; set; }
-			[XmlElement(ElementName = "WINDOWS")]
-			public WINDOWS WINDOWS { get; set; }
-			[XmlElement(ElementName = "NAME")]
-			public string NAME { get; set; }
-			[XmlElement(ElementName = "DESCRIPTION")]
-			public string DESCRIPTION { get; set; }
-			[XmlElement(ElementName = "FLAGS")]
-			public string FLAGS { get; set; }
-			[XmlAttribute(AttributeName = "INDEX")]
-			public string INDEX { get; set; }
-		}
+        [XmlRoot(ElementName = "IMAGE")]
+        public class IMAGE
+        {
+            [XmlElement(ElementName = "DIRCOUNT")]
+            public string DIRCOUNT { get; set; }
+            [XmlElement(ElementName = "FILECOUNT")]
+            public string FILECOUNT { get; set; }
+            [XmlElement(ElementName = "TOTALBYTES")]
+            public string TOTALBYTES { get; set; }
+            [XmlElement(ElementName = "HARDLINKBYTES")]
+            public string HARDLINKBYTES { get; set; }
+            [XmlElement(ElementName = "CREATIONTIME")]
+            public CREATIONTIME CREATIONTIME { get; set; }
+            [XmlElement(ElementName = "LASTMODIFICATIONTIME")]
+            public LASTMODIFICATIONTIME LASTMODIFICATIONTIME { get; set; }
+            [XmlElement(ElementName = "WINDOWS")]
+            public WINDOWS WINDOWS { get; set; }
+            [XmlElement(ElementName = "NAME")]
+            public string NAME { get; set; }
+            [XmlElement(ElementName = "DESCRIPTION")]
+            public string DESCRIPTION { get; set; }
+            [XmlElement(ElementName = "FLAGS")]
+            public string FLAGS { get; set; }
+            [XmlAttribute(AttributeName = "INDEX")]
+            public string INDEX { get; set; }
+        }
 
-		[XmlRoot(ElementName = "WIM")]
-		public class WIM
-		{
-			[XmlElement(ElementName = "TOTALBYTES")]
-			public string TOTALBYTES { get; set; }
-			[XmlElement(ElementName = "IMAGE")]
-			public IMAGE[] IMAGE { get; set; }
-		}
-	}
+        [XmlRoot(ElementName = "WIM")]
+        public class WIM
+        {
+            [XmlElement(ElementName = "TOTALBYTES")]
+            public string TOTALBYTES { get; set; }
+            [XmlElement(ElementName = "IMAGE")]
+            public IMAGE[] IMAGE { get; set; }
+        }
+    }
 }


### PR DESCRIPTION
I know this is a big old (highly opinionated) pull request with a lot of different things, but better to suffer now than down the line

* Use case-insensitive string comparisons rather than ToLower()
* Use indicies
* Use string.Join rather than manual looping
* Use readonly fields where possible
* Use hashsets for building types and editions listings
* Use spaces over tabs (previously mix of the two was used)
* Clean trailing whitespace
* Use brackets around all if statements
* Fix bug where Index 2 would lead to System32 being truncated to System3 in path names