### PR TITLE
Misc bugfixes; Support for reading EditionMappings.xml; Support for PID in setupp.ini

### DIFF
--- a/Windows Build Identifier/Comparer.cs
+++ b/Windows Build Identifier/Comparer.cs
@@ -87,7 +87,7 @@ namespace WindowsBuildIdentifier
 
         private static string Sanitize(string path1)
         {
-            if (path1.Contains(@"installedrepository\", StringComparison.InvariantCultureIgnoreCase))
+            if (path1.Contains(@"installedrepository\", StringComparison.OrdinalIgnoreCase))
             {
                 string fold1T = path1.ToLower().Split(@"installedrepository\")[0];
                 string fold1 = path1.ToLower().Split(@"installedrepository\")[1];
@@ -111,7 +111,7 @@ namespace WindowsBuildIdentifier
                 return f1;
             }
 
-            if (path1.Contains(@"build\filerepository\", StringComparison.InvariantCultureIgnoreCase))
+            if (path1.Contains(@"build\filerepository\", StringComparison.OrdinalIgnoreCase))
             {
                 string fold1T = path1.ToLower().Split(@"build\filerepository\")[0];
                 string fold1 = path1.ToLower().Split(@"build\filerepository\")[1];
@@ -135,7 +135,7 @@ namespace WindowsBuildIdentifier
                 return f1;
             }
 
-            if (path1.Contains(@"Windows\winsxs\", StringComparison.InvariantCultureIgnoreCase))
+            if (path1.Contains(@"Windows\winsxs\", StringComparison.OrdinalIgnoreCase))
             {
                 string fold1T = path1.ToLower().Split(@"windows\winsxs\")[0];
                 string fold1 = path1.ToLower().Split(@"windows\winsxs\")[1];
@@ -171,7 +171,7 @@ namespace WindowsBuildIdentifier
         {
             string index = @"install.wim\3\";
 
-            if (!path.Contains(index, StringComparison.InvariantCultureIgnoreCase))
+            if (!path.Contains(index, StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }

--- a/Windows Build Identifier/Identification/MediaHandler.cs
+++ b/Windows Build Identifier/Identification/MediaHandler.cs
@@ -84,11 +84,11 @@ namespace WindowsBuildIdentifier.Identification
             Console.WriteLine($"Found {wim.IMAGE.Length} images in the wim according to the XML");
 
             Console.WriteLine("Evaluating relevant images in the WIM according to the XML");
-            int irelevantcount2 = (wim.IMAGE.Any(x => x.DESCRIPTION != null && x.DESCRIPTION.Contains("winpe", StringComparison.InvariantCultureIgnoreCase)) ? 1 : 0) +
-                                  (wim.IMAGE.Any(x => x.DESCRIPTION != null && x.DESCRIPTION.Contains("setup", StringComparison.InvariantCultureIgnoreCase)) ? 1 : 0) +
-                                  (wim.IMAGE.Any(x => x.DESCRIPTION != null && x.DESCRIPTION.Contains("preinstallation", StringComparison.InvariantCultureIgnoreCase)) ? 1 : 0) +
-                                  (wim.IMAGE.Any(x => x.DESCRIPTION != null && x.DESCRIPTION.Contains("winre", StringComparison.InvariantCultureIgnoreCase)) ? 1 : 0) +
-                                  (wim.IMAGE.Any(x => x.DESCRIPTION != null && x.DESCRIPTION.Contains("recovery", StringComparison.InvariantCultureIgnoreCase)) ? 1 : 0);
+            int irelevantcount2 = (wim.IMAGE.Any(x => x.DESCRIPTION != null && x.DESCRIPTION.Contains("winpe", StringComparison.OrdinalIgnoreCase)) ? 1 : 0) +
+                                  (wim.IMAGE.Any(x => x.DESCRIPTION != null && x.DESCRIPTION.Contains("setup", StringComparison.OrdinalIgnoreCase)) ? 1 : 0) +
+                                  (wim.IMAGE.Any(x => x.DESCRIPTION != null && x.DESCRIPTION.Contains("preinstallation", StringComparison.OrdinalIgnoreCase)) ? 1 : 0) +
+                                  (wim.IMAGE.Any(x => x.DESCRIPTION != null && x.DESCRIPTION.Contains("winre", StringComparison.OrdinalIgnoreCase)) ? 1 : 0) +
+                                  (wim.IMAGE.Any(x => x.DESCRIPTION != null && x.DESCRIPTION.Contains("recovery", StringComparison.OrdinalIgnoreCase)) ? 1 : 0);
 
             Console.WriteLine($"Found {irelevantcount2} irrelevant images in the wim according to the XML");
 
@@ -103,11 +103,11 @@ namespace WindowsBuildIdentifier.Identification
                 // If what we're trying to identify isn't just a winpe, and we are accessing a winpe image
                 // skip the image
                 //
-                int irelevantcount = (image.DESCRIPTION != null && image.DESCRIPTION.Contains("winpe", StringComparison.InvariantCultureIgnoreCase) ? 1 : 0) +
-                                     (image.DESCRIPTION != null && image.DESCRIPTION.Contains("setup", StringComparison.InvariantCultureIgnoreCase) ? 1 : 0) +
-                                     (image.DESCRIPTION != null && image.DESCRIPTION.Contains("preinstallation", StringComparison.InvariantCultureIgnoreCase) ? 1 : 0) +
-                                     (image.DESCRIPTION != null && image.DESCRIPTION.Contains("winre", StringComparison.InvariantCultureIgnoreCase) ? 1 : 0) +
-                                     (image.DESCRIPTION != null && image.DESCRIPTION.Contains("recovery", StringComparison.InvariantCultureIgnoreCase) ? 1 : 0);
+                int irelevantcount = (image.DESCRIPTION != null && image.DESCRIPTION.Contains("winpe", StringComparison.OrdinalIgnoreCase) ? 1 : 0) +
+                                     (image.DESCRIPTION != null && image.DESCRIPTION.Contains("setup", StringComparison.OrdinalIgnoreCase) ? 1 : 0) +
+                                     (image.DESCRIPTION != null && image.DESCRIPTION.Contains("preinstallation", StringComparison.OrdinalIgnoreCase) ? 1 : 0) +
+                                     (image.DESCRIPTION != null && image.DESCRIPTION.Contains("winre", StringComparison.OrdinalIgnoreCase) ? 1 : 0) +
+                                     (image.DESCRIPTION != null && image.DESCRIPTION.Contains("recovery", StringComparison.OrdinalIgnoreCase) ? 1 : 0);
 
                 Console.WriteLine(
                     $"Index contains {irelevantcount} flags indicating this is a preinstallation environment");
@@ -141,6 +141,10 @@ namespace WindowsBuildIdentifier.Identification
                 provider.SetIndex(index);
 
                 WindowsImage report = DetectionHandler.IdentifyWindowsNT(provider);
+                if (report == null)
+                {
+                    continue;
+                }
 
                 // fallback
                 if ((string.IsNullOrEmpty(report.Sku) || report.Sku == "TerminalServer") &&
@@ -152,17 +156,17 @@ namespace WindowsBuildIdentifier.Identification
 
                     report.Types = new HashSet<Type>();
 
-                    if (report.Sku.Contains("server", StringComparison.InvariantCultureIgnoreCase) &&
-                        report.Sku.EndsWith("hyperv", StringComparison.InvariantCultureIgnoreCase) ||
-                        report.Sku.Contains("server", StringComparison.InvariantCultureIgnoreCase) &&
-                        report.Sku.EndsWith("v", StringComparison.InvariantCultureIgnoreCase))
+                    if (report.Sku.Contains("server", StringComparison.OrdinalIgnoreCase) &&
+                        report.Sku.EndsWith("hyperv", StringComparison.OrdinalIgnoreCase) ||
+                        report.Sku.Contains("server", StringComparison.OrdinalIgnoreCase) &&
+                        report.Sku.EndsWith("v", StringComparison.OrdinalIgnoreCase))
                     {
                         if (!report.Types.Contains(Type.ServerV))
                         {
                             report.Types.Add(Type.ServerV);
                         }
                     }
-                    else if (report.Sku.Contains("server", StringComparison.InvariantCultureIgnoreCase))
+                    else if (report.Sku.Contains("server", StringComparison.OrdinalIgnoreCase))
                     {
                         if (!report.Types.Contains(Type.Server))
                         {
@@ -226,6 +230,7 @@ namespace WindowsBuildIdentifier.Identification
 
             WindowsImage report = DetectionHandler.IdentifyWindowsNT(provider);
             report.Sku = fileSystem.GetSkuFromTxtSetupMedia(report.BuildNumber);
+            report.Licensing = fileSystem.GetLicensingFromTxtSetupMedia();
             report = DetectionHandler.FixSkuNames(report, false);
 
             Common.DisplayReport(report);
@@ -393,7 +398,7 @@ namespace WindowsBuildIdentifier.Identification
                                 try
                                 {
                                     if (fileItem.Location.Contains("txtsetup.sif",
-                                            StringComparison.InvariantCultureIgnoreCase))
+                                            StringComparison.OrdinalIgnoreCase))
                                     {
                                         TxtSetupBridge bridge = new(facade,
                                             string.Join("\\", fileItem.Location.Split('\\')[..^1]));

--- a/Windows Build Identifier/Program.cs
+++ b/Windows Build Identifier/Program.cs
@@ -88,7 +88,9 @@ namespace WindowsBuildIdentifier
             SortedSet<Licensing> licensings = new() { f.Licensing };
             SortedSet<string> languages = new(f.LanguageCodes ?? new[] { "lang-unknown" });
             SortedSet<string> skus = new() { f.Sku.Replace("Server", "") };
-            SortedSet<string> baseSkus = new() { f.Sku.Replace("Server", "") };
+            SortedSet<string> baseSkus = string.IsNullOrEmpty(f.BaseSku)
+                ? new()
+                : new() { f.BaseSku.Replace("Server", "") };
             SortedSet<string> archs = new() { $"{f.Architecture}{f.BuildType}" };
 
             for (int i = 1; i < imageIndexes.Length; i++)
@@ -207,16 +209,16 @@ namespace WindowsBuildIdentifier
 
                 WindowsImageIndex[] windowsImageIndexes = files[0].Metadata.WindowsImageIndexes;
 
-                if (files.Any(x => x.Location.EndsWith("install.wim", StringComparison.InvariantCultureIgnoreCase)))
+                if (files.Any(x => x.Location.EndsWith("install.wim", StringComparison.OrdinalIgnoreCase)))
                 {
-                    windowsImageIndexes = files.First(x => x.Location.EndsWith("install.wim")).Metadata
+                    windowsImageIndexes = files.First(x => x.Location.EndsWith("install.wim", StringComparison.OrdinalIgnoreCase)).Metadata
                         .WindowsImageIndexes;
                 }
                 else if (files.Any(
-                             x => x.Location.EndsWith("txtsetup.sif", StringComparison.InvariantCultureIgnoreCase)))
+                             x => x.Location.EndsWith("txtsetup.sif", StringComparison.OrdinalIgnoreCase)))
                 {
                     foreach (FileItem vfile in files.Where(x =>
-                                 x.Location.EndsWith("txtsetup.sif", StringComparison.InvariantCultureIgnoreCase)))
+                                 x.Location.EndsWith("txtsetup.sif", StringComparison.OrdinalIgnoreCase)))
                     {
                         windowsImageIndexes = windowsImageIndexes.Union(vfile.Metadata.WindowsImageIndexes).ToArray();
                     }
@@ -340,16 +342,16 @@ namespace WindowsBuildIdentifier
 
                 WindowsImageIndex[] windowsImageIndexes = files[0].Metadata.WindowsImageIndexes;
 
-                if (files.Any(x => x.Location.EndsWith("install.wim", StringComparison.InvariantCultureIgnoreCase)))
+                if (files.Any(x => x.Location.EndsWith("install.wim", StringComparison.OrdinalIgnoreCase)))
                 {
-                    windowsImageIndexes = files.First(x => x.Location.EndsWith("install.wim")).Metadata
+                    windowsImageIndexes = files.First(x => x.Location.EndsWith("install.wim", StringComparison.OrdinalIgnoreCase)).Metadata
                         .WindowsImageIndexes;
                 }
                 else if (files.Any(
-                             x => x.Location.EndsWith("txtsetup.sif", StringComparison.InvariantCultureIgnoreCase)))
+                             x => x.Location.EndsWith("txtsetup.sif", StringComparison.OrdinalIgnoreCase)))
                 {
                     foreach (FileItem vfile in files.Where(x =>
-                                 x.Location.EndsWith("txtsetup.sif", StringComparison.InvariantCultureIgnoreCase)))
+                                 x.Location.EndsWith("txtsetup.sif", StringComparison.OrdinalIgnoreCase)))
                     {
                         windowsImageIndexes = windowsImageIndexes.Union(vfile.Metadata.WindowsImageIndexes).ToArray();
                     }
@@ -900,7 +902,7 @@ namespace WindowsBuildIdentifier
             Console.WriteLine();
             Console.WriteLine("Windows Build Identifier (WBI)");
             Console.WriteLine("Gustave Monce (@gus33000) (c) 2018-2021");
-            Console.WriteLine("Thomas Hounsell (c) 2021");
+            Console.WriteLine("Thomas Hounsell (c) 2021-2022");
             Console.WriteLine();
         }
 

--- a/Windows Build Identifier/Windows Build Identifier.csproj
+++ b/Windows Build Identifier/Windows Build Identifier.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="ini-parser-netstandard" Version="2.5.2" />
-    <PackageReference Include="ManagedWimLib" Version="2.2.0" />
+    <PackageReference Include="ManagedWimLib" Version="2.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Some of my own misc fixes and improvements from over the past half year or so. I've not fully tested this merge yet, but it compiles OK so it's definitely ready to ship by MS standards.

Might yet bung a few other things in here.

* Update ManagedWimLib to 2.4.0
* Update copyright date
* Add support for reading parent editions of virtual SKUs from EditionMappings.xml
* Fix base SKU list for filename generation
* Switch to OrdinalIgnoreCase - this is the recommended comparison for path names, it should also be slightly quicker.
* Fix some errors thrown on real-world Windows ISOs
  * Where a WIM index doesn't contain a Windows install
  * No Base SKU available breaks renaming
  * Missing case insensitive comparison for install.wim name
* Add support for detecting OEM / VLK from PID in setupp.ini in I386-style installs